### PR TITLE
Make CartDNS use ByteCart API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>cz.majncraft.cartDNS</groupId>
 	<artifactId>CartDNS</artifactId>
-	<version>0.0.4</version>
+	<version>0.0.5</version>
 	<name>CartDNS</name>
 
 	<repositories>
@@ -11,10 +11,21 @@
 			<id>spigot-repo</id>
 			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
 		</repository>
+		<repository>
+			<id>repobcapi-rel</id>
+			<name>bytecart.catageek.info API Releases</name>
+			<url>http://bytecart.catageek.info/mavenAPI/repositories/releases/</url>
+		</repository>
+		<repository>
+			<id>repobcapi-snap</id>
+			<name>bytecart.catageek.info API Snapshots</name>
+			<url>http://bytecart.catageek.info/mavenAPI/repositories/snapshots/</url>
+		</repository>
 	</repositories>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<bytecartapi.version>2.8.3</bytecartapi.version>
 	</properties>
 
 	<build>
@@ -43,6 +54,12 @@
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
 			<version>1.8-R0.1-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.catageek</groupId>
+			<artifactId>ByteCartAPI</artifactId>
+			<version>${bytecartapi.version}</version>
+			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/cz/majncraft/cartDNS/CartDNS.java
+++ b/src/main/java/cz/majncraft/cartDNS/CartDNS.java
@@ -15,13 +15,27 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import com.github.catageek.ByteCartAPI.ByteCartAPI;
+import com.github.catageek.ByteCartAPI.AddressLayer.Address;
+import com.github.catageek.ByteCartAPI.AddressLayer.Resolver;
+import com.github.catageek.ByteCartAPI.Event.SignCreateEvent;
+import com.github.catageek.ByteCartAPI.Event.SignRemoveEvent;
+import com.github.catageek.ByteCartAPI.Event.UpdaterClearStationEvent;
+import com.github.catageek.ByteCartAPI.Event.UpdaterSetStationEvent;
+import com.github.catageek.ByteCartAPI.Event.UpdaterPassStationEvent;
+import com.github.catageek.ByteCartAPI.Signs.Station;
+
+import code.husky.Database;
 import code.husky.mysql.MySQL;
+import code.husky.sqlite.SQLite;
 
 
-public class CartDNS extends JavaPlugin{
-	MySQL mysql;
+public class CartDNS extends JavaPlugin implements Resolver,Listener {
+	Database mysql;
 	Connection con;
 	Statement s;
 	boolean err=false;
@@ -29,24 +43,16 @@ public class CartDNS extends JavaPlugin{
 	public void onLoad()
 	{
 		firstrun();
-		mysql = new MySQL(this, host, port, database, user, password);
+		if (sql.equalsIgnoreCase("mysql")) {
+			mysql = new MySQL(this, host, port, database, user, password);
+		}
+		else {
+			mysql = new SQLite(this, database);
+		}
 		con=mysql.openConnection();
 		try {
 			s = con.createStatement();
-			ResultSet res=s.executeQuery("show tables like 'cart_dns'");
-			if(res.next())
-			{
-				this.getLogger().info("Table cart_dns exist.");
-			}
-			else
-			{
-				this.getLogger().info("Table cart_dns dont exist. Creating new one.");
-				if(!s.execute("create table cart_dns (ip varchar(11) not null primary key,username varchar(20) not null,uuid varchar(128) not null,name varchar(20) not null unique key)"))
-				{
-					this.getLogger().info("Table cart_dns cannot be created.");
-					err=true; return;
-				}
-			}
+			s.execute("create table if not exists cart_dns (ip varchar(11) not null primary key,username varchar(20) not null,uuid varchar(128) not null,name varchar(20) not null unique)");
 		} catch (SQLException e) {
 			e.printStackTrace();
 		}
@@ -54,161 +60,214 @@ public class CartDNS extends JavaPlugin{
 	@Override
 	public void onEnable()
 	{
+		ByteCartAPI.setResolver(this);
+		getServer().getPluginManager().registerEvents(this, this);
 	}
+
 	@Override
 	public boolean onCommand(CommandSender a, Command b , String c, String[] d)
 	{
 		return onCommand(a,b,c,d,0);
 	}
+
 	public boolean onCommand(CommandSender a, Command b , String c, String[] d,int n)
-	{if(c.toLowerCase().equals("dns") && a.hasPermission("cartdns.manager"))
 	{
-		if(d.length==0)
+		if(c.toLowerCase().equals("dns"))
 		{
-			a.sendMessage("/dns create [hostname] [IP] - create DNS record.");
-			a.sendMessage("/dns lookup [hostname] - info about hostname.");
-			a.sendMessage("/dns lookup [IP]       - info about IP.");
-			a.sendMessage("/dns remove [hostname] - remove DNS record.");
-			a.sendMessage("/dns list [page] - list all DNS records.");
-			return true;
-		}
-		else if(d.length>=1)
-		{
-		// Strip diacritics from Station name
-			try{
-			switch(d[0])
+			if(d.length==0)
 			{
-			case "create":
-				d[1] = Normalizer.normalize(d[1], Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
-				if(!safeName(d[1]))
-				{
-					a.sendMessage("[CartDNS] No hacking this time");
-					return true;
-				}
-				else if(d.length<3 || safeIP(d[2])=="" || d[1].length()>20)
-				{
-					a.sendMessage("[CartDNS] Wrong IP/Name or not enought args.");
-					return true;
-				}
-				ResultSet res=s.executeQuery("SELECT * FROM `cart_dns` WHERE LOWER(`name`)='"+getName(d,1,1).toLowerCase()+"'");
-				
-				if(!res.next())
-				{
-					res=s.executeQuery("SELECT * FROM `cart_dns` WHERE `ip`='"+safeIP(d[2])+"'");
-					if(!res.next())
+				a.sendMessage("/dns create [hostname] [IP] - create DNS record.");
+				a.sendMessage("/dns lookup [hostname] - info about hostname.");
+				a.sendMessage("/dns lookup [IP]       - info about IP.");
+				a.sendMessage("/dns remove [hostname] - remove DNS record.");
+				a.sendMessage("/dns list [page] - list all DNS records.");
+				return true;
+			}
+			else if(d.length>=1)
+			{
+			// Strip diacritics from Station name
+				try{
+					switch(d[0])
 					{
-						String uu="Console",user="Console";
-						if((a instanceof Player))
-						{
-							uu=((Player)a).getUniqueId().toString();
-							user=((Player)a).getName();
+					case "create":
+						if (a.hasPermission("cartdns.manager")) {
+							d[1] = Normalizer.normalize(d[1], Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+							if(!safeName(d[1]))
+							{
+								a.sendMessage("[CartDNS] No hacking this time");
+								return true;
+							}
+							else if(d.length<3 || d[2].equals("") || d[1].length()>20)
+							{
+								a.sendMessage("[CartDNS] Wrong IP/Name or not enought args.");
+								return true;
+							}
+							if(!existEntryByName(getName(d,1,1), a))
+							{
+								String uu="Console",user="Console";
+								if((a instanceof Player))
+								{
+									uu=((Player)a).getUniqueId().toString();
+									user=((Player)a).getName();
+								}
+								createEntry(getName(d,1,1), safeIP(d[2]), uu, user);
+								a.sendMessage("[CartDNS] Added");
+							}
+							return true;
 						}
-						String ds="INSERT INTO `cart_dns` (`ip`,`name`,`username`,`uuid`) VALUES('"+safeIP(d[2])+"','"+getName(d,1,1)+"','"+user+"','"+uu+"')";
-						s.executeUpdate(ds);
-						a.sendMessage("[CartDNS] Added");
+						else {
+							a.sendMessage("[CartDNS] You don't have permission to use this command.");
+							return true;
+						}
+					case "remove":
+						if (a.hasPermission("cartdns.manager")) {
+							d[1] = Normalizer.normalize(d[1], Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+							if(!safeName(d[1]))
+							{
+								a.sendMessage("[CartDNS] No hacking this time");
+								return true;
+							}
+							if(removeEntry(getName(d,1,1))) {
+								a.sendMessage("[CartDNS] Deleted");
+								return true;
+							}
+						}
+						else {
+							a.sendMessage("[CartDNS] You don't have permission to use this command.");
+							return true;
+						}
+					case "list":
+						if((a.hasPermission("cartdns.manager")|| a.hasPermission("cartdns.user")))
+						{
+							if(d.length==0)
+							{
+								a.sendMessage("/dns list [page] - list all DNS records.");
+							}
+							else if(d.length>=1)
+							{
+								int listc=0;
+								if(d.length>=2 && d[1].matches("-?\\d+"))
+								{
+									listc=Integer.parseInt(d[1]);
+								}
+								try {
+								ResultSet res=s.executeQuery("SELECT * FROM `cart_dns` LIMIT "+(listc*10)+", "+(listc*10+10));
+									if(!res.next())
+										a.sendMessage("No DNS records");
+									else
+									{
+										a.sendMessage("DNS record table page ("+(listc+1)+")");
+										listc*=10;
+									do
+									{
+										a.sendMessage(listc+": "+res.getString("ip")+"    "+res.getString("name"));
+										listc++;
+									}
+									while(res.next());
+									}
+								} catch (SQLException e) {
+									if(n<2)
+									{
+										n++;
+										con=mysql.getConnection();
+										if(con==null)
+											con=mysql.openConnection();
+										return onCommand(a, b, c, d,n);
+									}
+									else
+									{
+										this.getLogger().info("SQL error code: "+e.getErrorCode());
+										this.getLogger().info("SQL error msg: "+e.getMessage());
+										this.getLogger().info("SQL error state: "+e.getSQLState());
+										return false;
+									}
+								}
+							}
+							return true;
+						}
+						break;
+					default:
+						// HAXX, if not /dns lookup, then make [name] first parameter
+						if (d[0].equalsIgnoreCase("lookup")) {
+							if (d.length==1) return false;
+							d[0] = d[1];
+						}
+						d[0] = Normalizer.normalize(d[0], Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+						if(!safeName(d[0]))
+						{
+							a.sendMessage("[CartDNS] No hacking this time");
+							return true;
+						}
+						if(!existEntryByName(getName(d,0,1)))
+						{
+							if(d[0].equals(""))
+								{a.sendMessage("[CartDNS] No dns with this name/ip"); return true;}
+							if(!existEntryByIP(safeIP(d[0])))
+							{
+								a.sendMessage("[CartDNS] No dns with this name/ip");
+							}
+							else
+							{
+								ResultSet ress = getEntryByIP(safeIP(d[0]));
+								a.sendMessage("[CartDNS] Name: "+ress.getString("name")+" IP: "+ress.getString("ip"));
+								a.sendMessage("[CartDNS] Author: "+ress.getString("username"));
+							}
+							return true;
+						}
+						else
+						{
+							ResultSet ress = getEntryByName(d[0]);
+							a.sendMessage("[CartDNS] Name: "+ress.getString("name")+" IP: "+ress.getString("ip"));
+							a.sendMessage("[CartDNS] Author: "+ress.getString("username"));
+							return true;
+						}
+					}
+				}
+				catch (SQLException e) {
+					if(n<2)
+					{
+						n++;
+						con=mysql.getConnection();
+						if(con==null)
+							con=mysql.openConnection();
+						return onCommand(a, b, c, d,n);
 					}
 					else
 					{
-						a.sendMessage("[CartDNS] DNS ip "+res.getString("ip")+" exist with name "+res.getString("name")+" .");
-						return true;
+						this.getLogger().info("SQL error code: "+e.getErrorCode());
+						this.getLogger().info("SQL error msg: "+e.getMessage());
+						this.getLogger().info("SQL error state: "+e.getSQLState());
+						return false;
 					}
-				}
-				else
-				{
-					a.sendMessage("[CartDNS] DNS name "+res.getString("name")+" exist with ip "+res.getString("ip")+" .");
-					return true;
-				}
-				break;
-			case "remove":
-				d[1] = Normalizer.normalize(d[1], Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
-				ResultSet resss=s.executeQuery("SELECT * FROM `cart_dns` WHERE LOWER(`name`)='"+getName(d,1,1).toLowerCase()+"'");
-				
-				if(resss.next())
-				{
-					s.executeUpdate("DELETE FROM `cart_dns` WHERE LOWER(`name`)='"+getName(d,1,1).toLowerCase()+"'");
-					a.sendMessage("[CartDNS] Deleted");
-					return true;
-				}
-				break;
-			default:
-				// HAXX, if not /dns lookup, then make [name] first parameter
-				if (d[0].equalsIgnoreCase("lookup")) {
-					if (d.length==1) return false;
-					d[0] = d[1];
-				}
-				d[0] = Normalizer.normalize(d[0], Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
-				ResultSet ress=s.executeQuery("SELECT * FROM `cart_dns` WHERE LOWER(`name`)='"+getName(d,0,1).toLowerCase()+"'");
-				if(!ress.next())
-				{
-					if(safeIP(d[0])=="")
-						{a.sendMessage("[CartDNS] No dns with this name/ip"); return true;}
-					ress=s.executeQuery("SELECT * FROM `cart_dns` WHERE `ip`='"+safeIP(d[0])+"'");
-					if(!ress.next())
-					{
-						a.sendMessage("[CartDNS] No dns with this name/ip");
-					}
-					else
-					{
-						a.sendMessage("[CartDNS] Name: "+ress.getString("name")+" IP: "+ress.getString("ip"));
-						a.sendMessage("[CartDNS] Author: "+ress.getString("username"));
-					}
-					return true;
-				}
-				else
-				{
-					a.sendMessage("[CartDNS] Name: "+ress.getString("name")+" IP: "+ress.getString("ip"));
-					a.sendMessage("[CartDNS] Author: "+ress.getString("username"));
-					return true;
 				}
 			}
 		}
-		catch (SQLException e) {
-			if(n<2)
-				{
-					n++;
-					con=mysql.getConnection();
-					if(con==null)
-						con=mysql.openConnection();
-					return onCommand(a, b, c, d,n);
-				}
-				else
-				{
-					this.getLogger().info("SQL error code: "+e.getErrorCode());
-					this.getLogger().info("SQL error msg: "+e.getMessage());
-					this.getLogger().info("SQL error state: "+e.getSQLState());
-					return false;
-				}
-		}
-		
-	}
-	}
-	if(c.toLowerCase().equals("dns") && (a.hasPermission("cartdns.manager")|| a.hasPermission("cartdns.user")))
-	{
-		if(d.length==0)
+		else if(c.toLowerCase().equals("dest") && a.hasPermission("cartdns.user"))
 		{
-			a.sendMessage("/dns list [page] - list all DNS records.");
-		}
-		else if(d.length>=1 && d[0]=="list")
-		{
-			int listc=1;
-			if(d.length>=2 && d[1].matches("-?\\d+"))
+			if(!(a instanceof Player))
 			{
-				listc=Integer.parseInt(d[1]);
+				a.sendMessage("Only players can use /dest");
+				return true;
+			}
+			if(d.length==0)
+			{
+				a.sendMessage("[DNS] Usage: /dest [name]");
+				return true;
 			}
 			try {
-			ResultSet res=s.executeQuery("SELECT * FROM `cart_dns` LIMIT "+(listc*10)+", "+(listc*10+10));
-				if(!res.next())
-					a.sendMessage("No DNS records");
+				d[0] = Normalizer.normalize(d[0], Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+				if(!safeName(getName(d,0,0)))
+					{a.sendMessage("No hacking this time"); return true;}
+				if(!existEntryByName(getName(d,0,0)))
+				{
+					a.sendMessage("[DNS] No IP for hostname "+getName(d,0,0));
+					return true;
+				}
 				else
 				{
-					a.sendMessage("DNS record table page ("+listc+")");
-					listc*=10;
-				do
-				{
-					a.sendMessage(listc+": "+res.getString("ip")+"    "+res.getString("name"));
-					listc++;
-				}
-				while(res.next());
+					ResultSet res = getEntryByName(getName(d,0,0));
+					((Player)a).performCommand("mego "+res.getString("ip"));
+					return true;
 				}
 			} catch (SQLException e) {
 				if(n<2)
@@ -228,60 +287,162 @@ public class CartDNS extends JavaPlugin{
 				}
 			}
 		}
-		return true;
+		else if(a instanceof Player)
+		{
+				Player bb=(Player)a;
+		}
+		return false;
 	}
-	else if(c.toLowerCase().equals("dest") && (a.hasPermission("cartdns.user")|| a.hasPermission("cartdns.user")))
-	{
-		if(!(a instanceof Player))
-		{
-			a.sendMessage("Only players can use /dest");
-			return true;
+
+	@EventHandler
+	public void onSignCreate(SignCreateEvent event) {
+		if (event.getIc() instanceof Station) {
+			try {
+				Station station = (Station) event.getIc();
+				String ip = station.getSignAddress().toString();
+				String name = station.getStationName();
+				Player player = event.getPlayer();
+				if (! ip.equals("") && ! name.equals("")) {
+					name = Normalizer.normalize(name, Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+					if (safeName(name) && ! existEntryByName(name,player))
+						createEntry(name, safeIP(ip), player.getUniqueId().toString(), player.getName());
+				}
+			} catch (SQLException e) {
+				this.getLogger().info("SQL error code: "+e.getErrorCode());
+				this.getLogger().info("SQL error msg: "+e.getMessage());
+				this.getLogger().info("SQL error state: "+e.getSQLState());
+			}
 		}
-		if(d.length==0)
-		{
-			a.sendMessage("[DNS] Usage: /dest [name]");
-			return true;
+	}
+
+	@EventHandler
+	public void onSignRemove(SignRemoveEvent event) {
+		if (event.getIc() instanceof Station) {
+			try {
+				String name = ((Station) event.getIc()).getStationName();
+				name = Normalizer.normalize(name, Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+				if (safeName(name))
+					removeEntry(name);
+			} catch (SQLException e) {
+				this.getLogger().info("SQL error code: "+e.getErrorCode());
+				this.getLogger().info("SQL error msg: "+e.getMessage());
+				this.getLogger().info("SQL error state: "+e.getSQLState());
+			}
 		}
+	}
+
+	@EventHandler
+	public void onUpdaterSetStation(UpdaterSetStationEvent event) {
 		try {
-		d[0] = Normalizer.normalize(d[0], Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
-		if(!safeName(getName(d,0,0)))
-			{a.sendMessage("No hacking this time"); return true;}
-		ResultSet res=s.executeQuery("SELECT * FROM `cart_dns` WHERE LOWER(`name`)='"+getName(d,0,0).toLowerCase()+"'");
-		if(!res.next())
+			String ip = event.getNewAddress().toString();
+			String name = event.getName();
+			if (! name.equals("")) {
+				name = Normalizer.normalize(name, Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+				if (safeName(name)) {
+					removeEntry(name);
+					createEntry(name, ip, "updater", "updater");
+				}
+			}
+		} catch (SQLException e) {
+			this.getLogger().info("SQL error code: "+e.getErrorCode());
+			this.getLogger().info("SQL error msg: "+e.getMessage());
+			this.getLogger().info("SQL error state: "+e.getSQLState());
+		}
+	}
+
+	@EventHandler
+	public void onUpdaterClearStation(UpdaterClearStationEvent event) {
+		try {
+			String name = event.getName();
+			if (! name.equals("")) {
+				name = Normalizer.normalize(name, Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+				if (safeName(name)) {
+					removeEntry(name);
+				}
+			}
+		} catch (SQLException e) {
+			this.getLogger().info("SQL error code: "+e.getErrorCode());
+			this.getLogger().info("SQL error msg: "+e.getMessage());
+			this.getLogger().info("SQL error state: "+e.getSQLState());
+		}
+	}
+
+	@EventHandler
+	public void onUpdaterPassStation(UpdaterPassStationEvent event) {
+		try {
+			String name = event.getName();
+			if (! name.equals("")) {
+				Address ip = event.getAddress();
+				name = Normalizer.normalize(name, Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+				getLogger().info("pass station name : " + name);
+				if (ip.isValid() && safeName(name) && ! existEntryByName(name)) {
+					createEntry(name, ip.toString(), "updater", "updater");
+				}
+			}
+		} catch (SQLException e) {
+			this.getLogger().info("SQL error code: "+e.getErrorCode());
+			this.getLogger().info("SQL error msg: "+e.getMessage());
+			this.getLogger().info("SQL error state: "+e.getSQLState());
+		}
+	}
+
+	public String resolve(String name) {
+		name = Normalizer.normalize(name, Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+		try {
+			if(safeName(name) && existEntryByName(name))
+				{
+					return getEntryByName(name).getString("ip");
+				}
+		} catch (SQLException e) {
+			this.getLogger().info("SQL error code: "+e.getErrorCode());
+			this.getLogger().info("SQL error msg: "+e.getMessage());
+			this.getLogger().info("SQL error state: "+e.getSQLState());
+		}
+		return "";
+	}
+
+	private boolean removeEntry(String name) throws SQLException {
+		if(existEntryByName(name))
 		{
-			a.sendMessage("[DNS] No IP for hostname "+getName(d,0,0));
+			s.executeUpdate("DELETE FROM `cart_dns` WHERE LOWER(`name`)='"+name.toLowerCase()+"'");
 			return true;
 		}
-		else
-		{
-				((Player)a).performCommand("mego "+res.getString("ip"));
-				return true;
-		}
-		} catch (SQLException e) {
-			if(n<2)
-				{
-					n++;
-					con=mysql.getConnection();
-					if(con==null)
-						con=mysql.openConnection();
-					return onCommand(a, b, c, d,n);
-				}
-				else
-				{
-					this.getLogger().info("SQL error code: "+e.getErrorCode());
-					this.getLogger().info("SQL error msg: "+e.getMessage());
-					this.getLogger().info("SQL error state: "+e.getSQLState());
-					return false;
-				}
-		}
-		
+		return false;
 	}
-	else if(a instanceof Player)
-	{
-			Player bb=(Player)a;
+
+
+	private boolean existEntryByName(String name, CommandSender a) throws SQLException {
+		if (existEntryByName(name)) {
+			ResultSet res = getEntryByName(name);
+			a.sendMessage("[CartDNS] DNS name "+res.getString("name")+" exist with ip "+res.getString("ip")+" .");
+			return true;
+		}
+		return false;
 	}
-	return false;
-}
+
+	private boolean existEntryByName(String name) throws SQLException {
+		ResultSet res=s.executeQuery("SELECT * FROM `cart_dns` WHERE LOWER(`name`)='"+name.toLowerCase()+"'");
+		return res.next();
+	}
+
+	private boolean existEntryByIP(String ip) throws SQLException {
+		ResultSet res=s.executeQuery("SELECT * FROM `cart_dns` WHERE `ip`='"+ ip +"'");
+		return res.next();
+	}
+
+	private ResultSet getEntryByName(String name) throws SQLException {
+		return s.executeQuery("SELECT * FROM `cart_dns` WHERE LOWER(`name`)='"+name.toLowerCase()+"'");
+	}
+
+	private  ResultSet getEntryByIP(String ip) throws SQLException {
+		return s.executeQuery("SELECT * FROM `cart_dns` WHERE `ip`='"+ip+"'");
+	}
+
+	private void createEntry(String name, String ip, String uu, String username) throws SQLException {
+		String ds="INSERT INTO `cart_dns` (`ip`,`name`,`username`,`uuid`) VALUES('"+ip+"','" + name +"','"+username+"','"+uu+"')";
+		s.executeUpdate(ds);
+	}
+
 	private String safeIP(String input)
 	{
 		char[] ch=input.toCharArray();
@@ -314,15 +475,16 @@ public class CartDNS extends JavaPlugin{
 	}
 	private boolean safeName(String input)
 	{
-		if(input.toLowerCase().contains(" OR ") || input.toLowerCase().contains(" AND "))
+		if(input.toLowerCase().contains(" or ") || input.toLowerCase().contains(" and ")
+				|| input.toLowerCase().contains(" union "))
 			return false;
-		Pattern p = Pattern.compile("[^a-z0-9\\s]", Pattern.CASE_INSENSITIVE);
+		Pattern p = Pattern.compile("[^a-z0-9/*+$!:.%@_\\-#&\\s]", Pattern.CASE_INSENSITIVE);
 		Matcher m = p.matcher(input);
 		if(m.find())
 			return false;
 		return true;
 	}
-	private String host,user,database,port,password;
+	private String host,user,database,port,password, sql;
 	private String getName(String[] input, int s, int e)
 	{
 		String output=input[s];
@@ -346,21 +508,25 @@ public class CartDNS extends JavaPlugin{
 		        config.set("port", "minecraft");
 		        config.set("user", "root");
 		        config.set("password", "root");
+		        config.set("sql", "sqllite");
 		        config.save(f);
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
     	}
         YamlConfiguration config = YamlConfiguration.loadConfiguration(f);
-    	if(config.isSet("hostname"))
-    		host=config.getString("hostname");
-    	if(config.isSet("port"))
-    		port=config.getString("port");
     	if(config.isSet("database"))
     		database=config.getString("database");
-    	if(config.isSet("user"))
-    		user=config.getString("user");
-    	if(config.isSet("password"))
-    		password=config.getString("password");
+		sql = config.getString("sql", "mysql");
+		if(sql.equalsIgnoreCase("mysql")) {
+			if(config.isSet("hostname"))
+				host=config.getString("hostname");
+			if(config.isSet("port"))
+				port=config.getString("port");
+			if(config.isSet("user"))
+				user=config.getString("user");
+			if(config.isSet("password"))
+				password=config.getString("password");
+		}
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: ${project.version}
 author: welfare93
 website: https://github.com/Majncraft/CartDNS
 main: cz.majncraft.cartDNS.CartDNS
+depend: [ByteCart]
 commands:
   dest:
     aliases: [destination]


### PR DESCRIPTION
Modifications I made before including the code in ByteCart and renaming the command 'host'. The final code in ByteCart is slightly modified.

I hope that you allow me to reuse your code (in fact I modified 50% of the original code to fix things). I credited your plugin on the ByteCart plugin page on bukkit dev.

The database is compatible, so you can uninstall CartDNS and use the embedded code if you wish.

Entries are now automatically created and removed using the 3rd line of
station signs as hostname. Updaters can record names automatically.

Fix a bug in DNS list preventing to run it if some permissions are not
set.

Refactor the whole code to allow calls from CommandExecutor or from
Listener.

Allow more special chars in hostnames and prevent injection of 'union'
in SQL statements.
